### PR TITLE
Externalise Vue in export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ export default [
       dir: 'lib',
       format: 'umd'
     },
+    external: ['vue'],
     plugins: [
       typescript({
         tsconfig: resolvedConfig => ({


### PR DESCRIPTION
Reduces file size of output from ~300 kb to ~20 kb (fixes issue https://github.com/room-js/typescript-vue-component-boilerplate/issues/4).
Fixes issue with duplicate Vue instances (issue https://github.com/room-js/typescript-vue-component-boilerplate/issues/6)